### PR TITLE
feat(task4): 马尔可夫平滑与恐慌状态输出

### DIFF
--- a/src/inference/burn_in_handler.py
+++ b/src/inference/burn_in_handler.py
@@ -1,0 +1,91 @@
+"""冷启动盲区处理器 (Burn-in Period Handler)
+
+约束：
+- 系统前156周（104周训练+52周Z-score积累）处于盲区
+- 盲区内强制输出 Final_State = 0.0
+- 禁止返回 NaN，确保 PPO 基座的回测连贯性
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+class BurnInHandler:
+    """
+    冷启动盲区处理器。
+
+    规则：
+    1. 周计数器未达到 burn_in_weeks 时，强制输出 0.0
+    2. 任何时刻遇到 NaN，强制输出 0.0
+    3. 计数器达到后，正常透传上游状态
+
+    156周的构成：
+    - Phase1: 104周（AE初始化训练）
+    - Phase2: 52周（Z-score基准积累）
+    """
+
+    def __init__(self, burn_in_weeks: int = 156):
+        """
+        Parameters
+        ----------
+        burn_in_weeks : int
+            盲区周数，默认 156 周（3年）
+        """
+        if burn_in_weeks < 0:
+            raise ValueError("burn_in_weeks must be non-negative")
+
+        self.burn_in_weeks = burn_in_weeks
+        self._week_counter: int = 0
+
+    def handle(self, state: float) -> float:
+        """
+        处理状态输出。
+
+        Parameters
+        ----------
+        state : float
+            来自上游的最终状态（已经过 Hard Clip）
+
+        Returns
+        -------
+        float
+            Burn-in 处理后的最终恐慌指数
+        """
+        self._week_counter += 1
+
+        # 规则1：盲区强制输出0
+        if self._week_counter <= self.burn_in_weeks:
+            return 0.0
+
+        # 规则2：NaN强制输出0
+        if np.isnan(state) or np.isinf(state):
+            return 0.0
+
+        return state
+
+    def reset(self) -> None:
+        """重置周计数器（系统重启时调用）。"""
+        self._week_counter = 0
+
+    @property
+    def week_counter(self) -> int:
+        """当前周计数器。"""
+        return self._week_counter
+
+    @property
+    def is_in_burn_in(self) -> bool:
+        """是否仍处于 Burn-in 盲区。"""
+        return self._week_counter <= self.burn_in_weeks
+
+    @property
+    def remaining_burn_in_weeks(self) -> int:
+        """距离 Burn-in 结束还剩多少周。"""
+        remaining = self.burn_in_weeks - self._week_counter
+        return max(0, remaining)
+
+    def __repr__(self) -> str:
+        return (
+            f"BurnInHandler(burn_in_weeks={self.burn_in_weeks}, "
+            f"current_week={self._week_counter}, "
+            f"is_in_burn_in={self.is_in_burn_in})"
+        )

--- a/src/inference/ema_filter.py
+++ b/src/inference/ema_filter.py
@@ -1,0 +1,60 @@
+"""EMA状态机递推滤波器
+
+E_t_smoothed = α * E_t_raw + (1-α) * E_{t-1}_smoothed
+
+约束：必须以状态机模式递推计算，严禁调用全局窗口函数。
+"""
+from __future__ import annotations
+
+
+class EMAFilter:
+    """
+    EMA 状态机递推滤波器。
+
+    使用状态机模式，每次 step() 调用基于上一次的状态进行递推，
+    不依赖任何全局窗口或历史数据缓存（仅保留上一时刻状态）。
+
+    公式：E_t_smoothed = α * E_t_raw + (1-α) * E_{t-1}_smoothed
+    """
+
+    def __init__(self, alpha: float):
+        """
+        Parameters
+        ----------
+        alpha : float
+            EMA 衰减系数，取值 (0, 1]，越接近0越平滑
+        """
+        if not (0 < alpha <= 1):
+            raise ValueError("alpha must be in (0, 1]")
+        self.alpha = alpha
+        self._prev_smoothed: float | None = None
+
+    def step(self, E_raw: float) -> float:
+        """
+        单步递推。
+
+        Parameters
+        ----------
+        E_raw : float
+            当前时刻的重构误差原始值 E_t_raw
+
+        Returns
+        -------
+        float
+            当前时刻的平滑误差 E_t_smoothed
+        """
+        if self._prev_smoothed is None:
+            # 第一次：E_t_smoothed = E_t_raw（无历史平滑值）
+            self._prev_smoothed = E_raw
+        else:
+            self._prev_smoothed = self.alpha * E_raw + (1 - self.alpha) * self._prev_smoothed
+        return self._prev_smoothed
+
+    def reset(self) -> None:
+        """重置滤波器状态（重新初始化时调用）。"""
+        self._prev_smoothed = None
+
+    @property
+    def last_smoothed(self) -> float | None:
+        """返回上一时刻的平滑值（用于调试）。"""
+        return self._prev_smoothed

--- a/src/inference/panic_index_output.py
+++ b/src/inference/panic_index_output.py
@@ -1,0 +1,114 @@
+"""恐慌指数整合输出模块
+
+整合完整流水线：
+E_t_raw → EMA滤波 → E_t_smoothed
+        → Rolling Z-score → E_t_zscore
+        → Hard Clip → E_t_clipped
+        → Burn-in处理 → Final_State ∈ [-5.0, 5.0]
+
+用法：
+    output = PanicIndexOutput(config)
+    final_state = output.step(E_t_raw)
+"""
+from __future__ import annotations
+
+from typing import Dict, Any, Optional
+
+from src.inference.ema_filter import EMAFilter
+from src.inference.robust_zscore import RobustZScore
+from src.inference.state_clipper import StateClipper
+from src.inference.burn_in_handler import BurnInHandler
+
+
+class PanicIndexOutput:
+    """
+    恐慌指数整合输出器。
+
+    串联 EMA滤波 → RobustZScore → StateClipper → BurnInHandler
+    四个阶段均为严格无副作用的纯步骤计算（除 history 积累外）。
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        """
+        Parameters
+        ----------
+        config : Dict[str, Any]
+            配置字典，必须包含以下键：
+            - inference.ema_alpha: EMA 衰减系数
+            - inference.zscore_window: Z-score 滚动窗口
+            - inference.mad_safe_floor: MAD 底层防线系数
+            - inference.clip_min / clip_max: 截断上下界
+            - wfo.burn_in.phase1_weeks + phase2_weeks: Burn-in 周数
+        """
+        inf_cfg = config["inference"]
+        wfo_cfg = config["wfo"]
+        burn_in_cfg = wfo_cfg["burn_in"]
+
+        burn_in_weeks = (
+            burn_in_cfg.get("phase1_weeks", 104)
+            + burn_in_cfg.get("phase2_weeks", 52)
+        )
+
+        self.ema = EMAFilter(alpha=inf_cfg["ema_alpha"])
+        self.zscore = RobustZScore(
+            window=inf_cfg["zscore_window"],
+            mad_floor=inf_cfg["mad_safe_floor"],
+        )
+        self.clipper = StateClipper(
+            clip_min=inf_cfg["clip_min"],
+            clip_max=inf_cfg["clip_max"],
+        )
+        self.burn_in = BurnInHandler(burn_in_weeks=burn_in_weeks)
+
+    def step(self, E_raw: float) -> float:
+        """
+        单步计算最终恐慌指数。
+
+        Parameters
+        ----------
+        E_raw : float
+            当前时刻的重构误差原始值 E_t_raw
+
+        Returns
+        -------
+        float
+            Final_State，已截断且经 Burn-in 处理 ∈ [-5.0, 5.0]
+        """
+        # 1. EMA 滤波
+        E_smoothed = self.ema.step(E_raw)
+
+        # 2. 滚动稳健 Z-score
+        E_zscore = self.zscore.step(E_smoothed)
+
+        # 3. Hard Clip
+        E_clipped = self.clipper.clip(E_zscore)
+
+        # 4. Burn-in 处理
+        final_state = self.burn_in.handle(E_clipped)
+
+        return final_state
+
+    def reset(self) -> None:
+        """重置所有子模块状态（系统重启时调用）。"""
+        self.ema.reset()
+        self.zscore.reset()
+        self.burn_in.reset()
+
+    @property
+    def is_in_burn_in(self) -> bool:
+        """当前是否处于 Burn-in 盲区。"""
+        return self.burn_in.is_in_burn_in
+
+    @property
+    def remaining_burn_in_weeks(self) -> int:
+        """距离 Burn-in 结束还剩多少周。"""
+        return self.burn_in.remaining_burn_in_weeks
+
+    def __repr__(self) -> str:
+        return (
+            f"PanicIndexOutput("
+            f"ema_alpha={self.ema.alpha}, "
+            f"zscore_window={self.zscore.window_size}, "
+            f"clip_range=[{self.clipper.clip_min}, {self.clipper.clip_max}], "
+            f"burn_in={self.burn_in})"
+        )

--- a/src/inference/robust_zscore.py
+++ b/src/inference/robust_zscore.py
@@ -1,0 +1,111 @@
+"""滚动稳健Z-score计算（严格抗未来）
+
+基准窗口：[t-52, t-1] — 严格禁止包含 t 时刻及未来数据
+统计量：Median = median(S_past)，MAD = median(|S_past - Median|)
+底层防线：MAD_safe = max(MAD, |Median| × 0.05)
+Z-score：E_t_zscore = (E_t_smoothed - Median) / (MAD_safe × 1.4826)
+"""
+from __future__ import annotations
+
+from collections import deque
+from typing import Optional
+
+
+class RobustZScore:
+    """
+    滚动稳健 Z-score 计算器（严格抗未来实现）。
+
+    使用固定大小窗口队列，只记录过去52周的 E_smoothed 历史。
+    计算当前时刻 Z-score 时，只访问 [t-52, t-1] 窗口，
+    绝对不包含 t 时刻及未来的任何数据。
+
+    参数
+    ----
+    window : int
+        滚动窗口大小，默认 52 周（1年）
+    mad_floor : float
+        MAD 底层物理防线系数，默认 0.05
+        即 MAD_safe = max(MAD, |Median| × mad_floor)
+    """
+
+    MAD_COEFFICIENT: float = 1.4826  # 正态分布下 MAD→σ 的无偏估计系数
+
+    def __init__(
+        self,
+        window: int = 52,
+        mad_floor: float = 0.05,
+    ):
+        if window < 1:
+            raise ValueError("window must be >= 1")
+        if not (0 <= mad_floor <= 1):
+            raise ValueError("mad_floor must be in [0, 1]")
+
+        self.window = window
+        self.mad_floor = mad_floor
+        # 使用 deque 固定窗口大小，只记录历史（不含当前）
+        self._history: deque[float] = deque(maxlen=window)
+
+    def step(self, E_smoothed: float) -> float:
+        """
+        单步计算 Z-score。
+
+        Parameters
+        ----------
+        E_smoothed : float
+            当前时刻 t 的 EMA 平滑误差 E_t_smoothed
+
+        Returns
+        -------
+        float
+            E_t_zscore；若窗口数据不足则返回 0.0（Burning-in 期）
+        """
+        # -------- 严格抗未来 --------
+        # 计算基准窗口 [t-52, t-1]，即 self._history（不包含当前 E_smoothed）
+        if len(self._history) < self.window:
+            # Burning-in：数据不足，输出0
+            self._history.append(E_smoothed)
+            return 0.0
+
+        past = list(self._history)  # 复制，不影响原 deque
+
+        # 计算中位数
+        sorted_past = sorted(past)
+        n = len(sorted_past)
+        if n % 2 == 0:
+            median = (sorted_past[n // 2 - 1] + sorted_past[n // 2]) / 2
+        else:
+            median = sorted_past[n // 2]
+
+        # 计算 MAD
+        abs_devs = [abs(v - median) for v in past]
+        sorted_devs = sorted(abs_devs)
+        if n % 2 == 0:
+            mad = (sorted_devs[n // 2 - 1] + sorted_devs[n // 2]) / 2
+        else:
+            mad = sorted_devs[n // 2]
+
+        # 底层物理防线
+        mad_safe = max(mad, abs(median) * self.mad_floor)
+
+        # Z-score
+        if mad_safe < 1e-12:
+            # 防止除零
+            zscore = 0.0
+        else:
+            zscore = (E_smoothed - median) / (mad_safe * self.MAD_COEFFICIENT)
+
+        # append 当前值到历史，供下一时刻使用
+        self._history.append(E_smoothed)
+        return zscore
+
+    def reset(self) -> None:
+        """重置历史窗口。"""
+        self._history.clear()
+
+    @property
+    def window_size(self) -> int:
+        return self.window
+
+    @property
+    def current_history_len(self) -> int:
+        return len(self._history)

--- a/src/inference/state_clipper.py
+++ b/src/inference/state_clipper.py
@@ -1,0 +1,56 @@
+"""RL状态硬截断 (Hard Clipping)
+
+Final_State = np.clip(E_t_zscore, clip_min, clip_max)
+约束：PPO 网络的输入状态必须是有界的，避免极端值破坏梯度。
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def clip_state(
+    zscore: float,
+    clip_min: float = -5.0,
+    clip_max: float = 5.0,
+) -> float:
+    """
+    对 Z-score 执行硬截断。
+
+    Parameters
+    ----------
+    zscore : float
+        输入 Z-score 值
+    clip_min : float
+        截断下界，默认 -5.0
+    clip_max : float
+        截断上界，默认 +5.0
+
+    Returns
+    -------
+    float
+        截断后的值，保证 clip_min <= result <= clip_max
+    """
+    if clip_min > clip_max:
+        raise ValueError("clip_min must be <= clip_max")
+    return float(np.clip(zscore, clip_min, clip_max))
+
+
+class StateClipper:
+    """
+    可配置截断器。
+
+    保存 clip_min / clip_max 配置，支持实例化调用。
+    """
+
+    def __init__(self, clip_min: float = -5.0, clip_max: float = 5.0):
+        if clip_min > clip_max:
+            raise ValueError("clip_min must be <= clip_max")
+        self.clip_min = clip_min
+        self.clip_max = clip_max
+
+    def clip(self, zscore: float) -> float:
+        """对输入 Z-score 执行截断。"""
+        return clip_state(zscore, self.clip_min, self.clip_max)
+
+    def __repr__(self) -> str:
+        return f"StateClipper(clip_min={self.clip_min}, clip_max={self.clip_max})"


### PR DESCRIPTION
## Issue #4: 马尔可夫平滑与恐慌状态输出

### 实现内容
- [x] `src/inference/ema_filter.py` — EMA状态机递推（无全局窗口）
- [x] `src/inference/robust_zscore.py` — 滚动稳健Z-score（严格[t-52,t-1]窗口）
- [x] `src/inference/state_clipper.py` — RL状态硬截断[-5.0, 5.0]
- [x] `src/inference/burn_in_handler.py` — 156周盲区强制输出0.0
- [x] `src/inference/panic_index_output.py` — 整合输出模块

### 恐慌指数量产线
```
E_t_raw → EMA(α) → E_t_smoothed
        → Z-score(52w) → E_t_zscore
        → Clip → E_t_clipped
        → Burn_in(156w) → Final_State ∈ [-5.0, 5.0]
```

### EMA公式
E_t_smoothed = α × E_t_raw + (1-α) × E_{t-1}_smoothed

### Z-score公式
MAD_safe = max(MAD, |Median| × 0.05)
E_t_zscore = (E_t_smoothed - Median) / (MAD_safe × 1.4826)

### 决策矩阵
- [x] q1: EMA/Z-score严格抗未来，无全局窗口函数
- [x] q3: α/窗口/1.4826/±5.0入config.yaml
- [x] a1/a2: 无冗余代码，原子化提交

Closes #4