### PR TITLE
feat(module2-task1): LLM异步宏观语义引擎

### DIFF
--- a/src/llm_engine/__init__.py
+++ b/src/llm_engine/__init__.py
@@ -1,0 +1,16 @@
+"""LLM Async Macro Semantic Engine — AE_LLM_RL_FOF Module2"""
+
+from src.llm_engine.async_semantic_engine import AsyncSemanticEngine
+from src.llm_engine.concept_pools import CONCEPT_POOLS, DIMENSIONS
+from src.llm_engine.prompt_builder import PromptBuilder
+from src.llm_engine.response_parser import ResponseParser
+from src.llm_engine.text_etl import TextETL
+
+__all__ = [
+    "AsyncSemanticEngine",
+    "CONCEPT_POOLS",
+    "DIMENSIONS",
+    "PromptBuilder",
+    "ResponseParser",
+    "TextETL",
+]

--- a/src/llm_engine/async_semantic_engine.py
+++ b/src/llm_engine/async_semantic_engine.py
@@ -1,0 +1,95 @@
+"""Async LLM macro semantic engine — weekly Friday evaluation pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+
+from openai import AsyncOpenAI
+
+from src.llm_engine.concept_pools import DIMENSIONS, CONCEPT_POOLS
+from src.llm_engine.prompt_builder import PromptBuilder
+from src.llm_engine.response_parser import ParseError, ResponseParser
+from src.llm_engine.text_etl import TextETL
+
+
+class LLMCallError(RuntimeError):
+    """Raised when LLM invocation fails after all retries."""
+
+
+class AsyncSemanticEngine:
+    """Async LLM engine for weekly macro concept scoring.
+
+    Pipeline: ETL → PromptBuilder → AsyncOpenAI → ResponseParser → scores
+    """
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.llm_config = config["llm"]
+        self.client = AsyncOpenAI(api_key=self.llm_config["api_key"])
+        self.etl = TextETL(config)
+        self.prompt_builder = PromptBuilder()
+        self.parser = ResponseParser()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def evaluate(self, current_date: str) -> dict[str, dict[str, float]]:
+        """Run full evaluation pipeline for the given Friday date.
+
+        Parameters
+        ----------
+        current_date : str
+            Friday date in YYYY-MM-DD format.
+
+        Returns
+        -------
+        dict[str, dict[str, float]]
+            {concept_name: {"d1": float, "d2": float, "d3": float}}
+
+        Raises
+        ------
+        LLMCallError
+            If LLM call fails after max retries.
+        ParseError
+            If LLM output fails validation.
+        """
+        # 1. ETL
+        etl_data = self.etl.extract_all(current_date)
+
+        # 2. Build prompt (prefer config concept_pools, fallback to module constant)
+        concept_pools = self.config.get("concept_pools", CONCEPT_POOLS)
+        prompt = self.prompt_builder.build(etl_data, concept_pools)
+
+        # 3. LLM call with retry
+        response = await self._call_llm_with_retry(prompt)
+
+        # 4. Parse
+        scores = self.parser.parse(response)
+        return scores
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    async def _call_llm_with_retry(self, prompt: str) -> str:
+        """Call AsyncOpenAI with exponential-backoff retry."""
+        max_retries = self.llm_config.get("max_retries", 3)
+        for attempt in range(max_retries):
+            try:
+                response = await self.client.chat.completions.create(
+                    model=self.llm_config.get("model", "gpt-4o-mini"),
+                    messages=[
+                        {"role": "system", "content": PromptBuilder.SYSTEM_PROMPT},
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.0,
+                    response_format={"type": "json_object"},
+                )
+                return response.choices[0].message.content
+            except Exception as e:
+                if attempt == max_retries - 1:
+                    raise LLMCallError(f"LLM调用失败 {max_retries}次: {e}") from e
+                await asyncio.sleep(2**attempt)
+        # Defensive: should not reach here
+        raise LLMCallError("重试耗尽")

--- a/src/llm_engine/concept_pools.py
+++ b/src/llm_engine/concept_pools.py
@@ -1,0 +1,16 @@
+"""Concept pool definitions — configurable concept universe for macro scoring."""
+
+# Three concept pools: wide-base, satellite, fixed-income
+# Keys match config.yaml (concept_pools.wide_base / satellite / fixed_income)
+CONCEPT_POOLS = {
+    "wide_base": ["沪深300", "中证1000"],
+    "satellite": ["人工智能", "创新药", "半导体", "煤炭", "新能源", "红利低波"],
+    "fixed_income": ["长期利率债", "信用债"],
+}
+
+# Dimension semantics for LLM prompt construction
+DIMENSIONS = {
+    "d1": "流动性顺风（流动性与政策支撑度）",
+    "d2": "资金情绪（新闻看多一致性）",
+    "d3": "尾部风险（政策打压或地缘风险）",
+}

--- a/src/llm_engine/prompt_builder.py
+++ b/src/llm_engine/prompt_builder.py
@@ -1,0 +1,83 @@
+"""Build LLM prompts from ETL text data and concept pool definitions."""
+
+from __future__ import annotations
+
+from src.llm_engine.concept_pools import CONCEPT_POOLS, DIMENSIONS
+
+
+class PromptBuilder:
+    """Aggregate ETL text into a structured prompt for macro concept scoring."""
+
+    SYSTEM_PROMPT = """你是一个专业的宏观策略分析师。请根据以下文本信息，对各个概念进行评分。
+输出必须为严格的JSON格式，包含所有概念的d1/d2/d3评分（浮点数，值域1.0~100.0）。
+维度说明：
+- d1: 流动性顺风（流动性与政策支撑度，越高越好）
+- d2: 资金情绪（新闻看多一致性，越高越看多）
+- d3: 尾部风险（政策打压或地缘风险，越高风险越大）
+"""
+
+    def build(self, etl_data: dict, concept_pools: dict = None) -> str:
+        """Build the user prompt from ETL data and concept pools.
+
+        Parameters
+        ----------
+        etl_data : dict
+            Output from TextETL.extract_all().
+        concept_pools : dict, optional
+            Override CONCEPT_POOLS. Defaults to the module-level constant.
+
+        Returns
+        -------
+        str
+            Complete user prompt string.
+        """
+        if concept_pools is None:
+            concept_pools = CONCEPT_POOLS
+
+        sections: list[str] = []
+
+        # --- 1. PBoC MPC ---
+        zgrmyh = etl_data.get("zgrmyh") or []
+        if zgrmyh:
+            rec = zgrmyh[0]
+            content = rec.get("content") or rec.get("title") or "（内容暂无）"
+            sections.append(
+                f"【货币政策例会】\n日期：{rec.get('date', 'N/A')}\n标题：{rec.get('title', 'N/A')}\n内容：{content}"
+            )
+
+        # --- 2. CSRC titles ---
+        csrc = etl_data.get("csrc_titles") or []
+        if csrc:
+            titles = "\n".join(f"- {t}" for t in csrc[:20])
+            sections.append(f"【证监会动态】（近7天，共{len(csrc)}条）\n{titles}")
+
+        # --- 3. Global govcn ---
+        govcn = etl_data.get("govcn_global") or []
+        if govcn:
+            items = "\n".join(f"- {g.get('title', '')}" for g in govcn[:20])
+            sections.append(f"【全局政策动态】（近7天，共{len(govcn)}条）\n{items}")
+
+        # --- 4. Concept pool summary (English key → Chinese display name) ---
+        DISPLAY_NAMES = {
+            "wide_base": "宽基池",
+            "satellite": "卫星池",
+            "fixed_income": "固收池",
+        }
+        pool_lines: list[str] = []
+        for pool_key, concepts in concept_pools.items():
+            display = DISPLAY_NAMES.get(pool_key, pool_key)
+            pool_lines.append(f"  {display}：{', '.join(concepts)}")
+        pool_summary = "\n".join(pool_lines)
+
+        # --- 5. Dimension reference ---
+        dim_lines = "\n".join(f"  {k}: {v}" for k, v in DIMENSIONS.items())
+
+        user_prompt = (
+            f"【待评分概念池】\n{pool_summary}\n\n"
+            f"【维度定义】\n{dim_lines}\n\n"
+            f"【近期宏观文本】\n" + "\n\n".join(sections) + "\n\n"
+            "请对每个概念输出JSON，格式：\n"
+            "{\n  \"概念名\": {\"d1\": float, \"d2\": float, \"d3\": float},\n  ...\n}\n"
+            "所有评分必须在1.0~100.0范围内。"
+        )
+        return user_prompt

--- a/src/llm_engine/response_parser.py
+++ b/src/llm_engine/response_parser.py
@@ -1,0 +1,72 @@
+"""Parse and validate LLM JSON responses for macro concept scores."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class ParseError(ValueError):
+    """Raised when LLM output cannot be parsed or fails validation."""
+
+
+class ResponseParser:
+    """Parse LLM JSON output and validate d1/d2/d3 score ranges."""
+
+    MIN_SCORE = 1.0
+    MAX_SCORE = 100.0
+    REQUIRED_DIMENSIONS = {"d1", "d2", "d3"}
+
+    def parse(self, raw: str) -> dict[str, dict[str, float]]:
+        """Parse and validate LLM JSON response.
+
+        Parameters
+        ----------
+        raw : str
+            Raw JSON string from LLM response.
+
+        Returns
+        -------
+        dict[str, dict[str, float]]
+            Mapping of concept name -> {d1, d2, d3} scores.
+
+        Raises
+        ------
+        ParseError
+            If JSON is malformed or any score is out of [1.0, 100.0] range.
+        """
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ParseError(f"JSON decode error: {e}") from e
+
+        if not isinstance(data, dict):
+            raise ParseError(f"Expected JSON object, got {type(data).__name__}")
+
+        self._validate_scores(data)
+        return data
+
+    def _validate_scores(self, data: dict) -> None:
+        """Validate that every concept entry has valid d1/d2/d3 scores."""
+        for concept, scores in data.items():
+            if not isinstance(scores, dict):
+                raise ParseError(
+                    f"Concept '{concept}': expected dict of scores, got {type(scores).__name__}"
+                )
+            missing = self.REQUIRED_DIMENSIONS - set(scores.keys())
+            if missing:
+                raise ParseError(
+                    f"Concept '{concept}' missing dimensions: {missing}"
+                )
+            for dim in self.REQUIRED_DIMENSIONS:
+                val = scores.get(dim)
+                if not isinstance(val, (int, float)):
+                    raise ParseError(
+                        f"Concept '{concept}', dimension '{dim}': "
+                        f"expected float, got {type(val).__name__}"
+                    )
+                if not (self.MIN_SCORE <= float(val) <= self.MAX_SCORE):
+                    raise ParseError(
+                        f"Concept '{concept}', dimension '{dim}': "
+                        f"value {val} outside [{self.MIN_SCORE}, {self.MAX_SCORE}]"
+                    )

--- a/src/llm_engine/text_etl.py
+++ b/src/llm_engine/text_etl.py
@@ -1,0 +1,129 @@
+"""Text ETL — extract text data from quantchdb within strict time windows.
+
+Time windows enforced:
+  - [t-30, t]  for concept-matched govcn (broad search)
+  - [t-7,  t]  for CSRC, govcn global, and news titles
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from quantchdb import ClickHouseDatabase
+
+
+class TextETL:
+    """Extract macro text data from quantchdb, strictly within [t-30,t] / [t-7,t] windows."""
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        db_cfg = config["data_pipeline"]["track_b"]["db_config"]
+        self.db = ClickHouseDatabase(config=db_cfg)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def extract_all(self, t: str) -> dict:
+        """Extract all text data for date t.
+
+        Returns
+        -------
+        dict
+            Keys: zgrmyh, csrc_titles, govcn_global
+        """
+        return {
+            "zgrmyh": self.fetch_zgrmyh(t),
+            "csrc_titles": self.fetch_csrc_titles(t),
+            "govcn_global": self.fetch_govcn_global(t),
+        }
+
+    # ------------------------------------------------------------------
+    # Individual fetchers
+    # ------------------------------------------------------------------
+
+    def fetch_zgrmyh(self, t: str) -> list[dict]:
+        """Return the most recent PBoC MPC meeting record with date <= t."""
+        sql = (
+            f"SELECT uuid, title, date, date_time, url, content "
+            f"FROM text_db.zgrmyh "
+            f"WHERE date <= '{t}' "
+            f"ORDER BY date DESC LIMIT 1"
+        )
+        return self.db.fetch(sql).to_dicts()
+
+    def fetch_csrc_titles(self, t: str) -> list[str]:
+        """CSRC titles published within [t-7, t]."""
+        sql = (
+            f"SELECT title "
+            f"FROM text_db.csrc "
+            f"WHERE date BETWEEN dateSub(7, DAY, '{t}') AND '{t}' "
+            f"ORDER BY date DESC"
+        )
+        result = self.db.fetch(sql)
+        return result["title"].tolist() if not result.empty else []
+
+    def fetch_govcn_global(self, t: str) -> list[dict]:
+        """Global (industry_name = '') govcn policies within [t-7, t]."""
+        sql = (
+            f"SELECT title, content, date, passage_type "
+            f"FROM text_db.govcn "
+            f"WHERE date BETWEEN dateSub(7, DAY, '{t}') AND '{t}' "
+            f"AND industry_name = '' "
+            f"ORDER BY date DESC"
+        )
+        return self.db.fetch(sql).to_dicts()
+
+    def fetch_govcn_by_concept(self, concept: str, t: str, lookback: int = 30) -> list[dict]:
+        """Fuzzy-match govcn by concept within [t-lookback, t]."""
+        sql = (
+            f"SELECT title, content, date, passage_type "
+            f"FROM text_db.govcn "
+            f"WHERE date BETWEEN dateSub({lookback}, DAY, '{t}') AND '{t}' "
+            f"AND (title LIKE '%{concept}%' OR content LIKE '%{concept}%') "
+            f"ORDER BY date DESC"
+        )
+        return self.db.fetch(sql).to_dicts()
+
+    def fetch_news_titles(
+        self,
+        source: str,
+        t: str,
+        concept: Optional[str] = None,
+        limit: int = 20,
+    ) -> list[str]:
+        """Fetch up to `limit` news titles from eastmoney/sina within [t-7, t].
+
+        Parameters
+        ----------
+        source : str
+            "eastmoney" or "sina"
+        t : str
+            Reference date in YYYY-MM-DD.
+        concept : str, optional
+            If given, only titles matching the concept are returned.
+        limit : int, default 20
+            Maximum number of titles to return (Top-20 truncation per spec).
+
+        Returns
+        -------
+        list[str]
+        """
+        table = f"text_db.{source}"
+        if concept:
+            sql = (
+                f"SELECT title, date "
+                f"FROM {table} "
+                f"WHERE date BETWEEN dateSub(7, DAY, '{t}') AND '{t}' "
+                f"AND (title LIKE '%{concept}%' OR content LIKE '%{concept}%') "
+                f"ORDER BY date DESC LIMIT {limit}"
+            )
+        else:
+            sql = (
+                f"SELECT title, date "
+                f"FROM {table} "
+                f"WHERE date BETWEEN dateSub(7, DAY, '{t}') AND '{t}' "
+                f"ORDER BY date DESC LIMIT {limit}"
+            )
+        result = self.db.fetch(sql)
+        return result["title"].tolist()[:limit] if not result.empty else []


### PR DESCRIPTION
## Issue #9: LLM异步宏观语义引擎

### 实现内容
- [x] src/llm_engine/text_etl.py — quantchdb文本查询（严格[t-30,t]/[t-7,t]）
- [x] src/llm_engine/concept_pools.py — 概念库配置（宽基/卫星/固收）
- [x] src/llm_engine/prompt_builder.py — Prompt拼接
- [x] src/llm_engine/response_parser.py — JSON解析（d1/d2/d3 ∈ [1.0,100.0]）
- [x] src/llm_engine/async_semantic_engine.py — AsyncOpenAI异步调用
- [x] config.yaml — llm/api配置 + concept_pools
- [x] pyproject.toml — openai>=1.0

### API约束
- temperature=0.0
- response_format=json_object
- 最大重试3次

### 约束红线
- [x] q1: 无未来函数（SQL窗口严格[t-30,t]/[t-7,t]）
- [x] q3: API key/model/timeout/concept pools入config.yaml
- [x] a1/a2: 无冗余代码，原子化提交

Closes #9