### PR TITLE
feat(module2-task2): 本地非对称扩维筛选

### DIFF
--- a/src/selection/__init__.py
+++ b/src/selection/__init__.py
@@ -1,0 +1,22 @@
+"""Selection module: asymmetric expansion dimensionality filtering for FOF portfolio construction."""
+
+from .asymmetric_argmax import AsymmetricSelector
+from .clickhouse_hard_clip import ETFSelector
+from .concept_to_etf_map import (
+    DEFAULT_ETF_POOLS,
+    CONCEPT_CATEGORY_MAP,
+    get_etf_pool_by_concept,
+    get_concepts_by_category,
+)
+from .slot_weighting import P_VECTORS, compute_slot_score
+
+__all__ = [
+    "AsymmetricSelector",
+    "ETFSelector",
+    "DEFAULT_ETF_POOLS",
+    "CONCEPT_CATEGORY_MAP",
+    "P_VECTORS",
+    "compute_slot_score",
+    "get_etf_pool_by_concept",
+    "get_concepts_by_category",
+]

--- a/src/selection/asymmetric_argmax.py
+++ b/src/selection/asymmetric_argmax.py
@@ -1,0 +1,157 @@
+"""Asymmetric truncation selection: maps LLM scores to 8-slot FOF portfolio.
+
+Slot rules:
+  0_宽基   -> Score rank 1  (wide_base concept with highest score)
+  1_卫星_1 -> Score rank 1 among remaining satellite concepts
+  2_卫星_2 -> Score rank 2 among remaining satellite concepts
+  3_卫星_3 -> Score rank 3 among remaining satellite concepts
+  4_固收_利率债 -> fixed_income concept "长期利率债" (dumbbell leg 1)
+  5_固收_信用债 -> fixed_income concept "信用债" (dumbbell leg 2)
+  6_避险   -> Fixed gold ETF: 518880.SH
+  7_现金   -> Fixed money market ETF: 511850.SH
+"""
+
+from typing import Dict, Optional
+
+from .clickhouse_hard_clip import ETFSelector
+from .concept_to_etf_map import (
+    CONCEPT_CATEGORY_MAP,
+    DEFAULT_ETF_POOLS,
+    FIXED_SLOT_ETFS,
+    get_etf_pool_by_concept,
+)
+from .slot_weighting import P_VECTORS, compute_slot_score
+
+
+class AsymmetricSelector:
+    """Asymmetric truncation selector for 8-slot FOF portfolio construction."""
+
+    # 8 fixed slot names
+    SLOT_NAMES = [
+        "0_宽基",
+        "1_卫星_1",
+        "2_卫星_2",
+        "3_卫星_3",
+        "4_固收_利率债",
+        "5_固收_信用债",
+        "6_避险",
+        "7_现金",
+    ]
+
+    def __init__(
+        self,
+        config: dict,
+        etf_pools: Optional[dict] = None,
+    ):
+        """Initialize with runtime config and optional ETF pool override."""
+        self.config = config
+        self.etf_pools = etf_pools if etf_pools is not None else DEFAULT_ETF_POOLS
+        self.sel = ETFSelector(config)
+        self._liquid_min = config["selection"]["liquidity_min_amt"]
+        self._momentum_window = config["selection"]["momentum_window"]
+
+    def _score_concepts_for_category(
+        self,
+        llm_scores: Dict[str, Dict[str, float]],
+        category: str,
+    ) -> list[tuple[str, float, str]]:
+        """Score all concepts in a category, return sorted (concept, score, pool_type)."""
+        scored = []
+        for concept, dims in llm_scores.items():
+            if CONCEPT_CATEGORY_MAP.get(concept) != category:
+                continue
+            d1 = dims.get("d1", 50.0)
+            d2 = dims.get("d2", 50.0)
+            d3 = dims.get("d3", 50.0)
+            score = compute_slot_score(d1, d2, d3, category)
+            scored.append((concept, score, category))
+        # Sort descending by score
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return scored
+
+    def _select_one_by_concept(
+        self,
+        concept: str,
+        t: str,
+        pool_type: str,
+    ) -> Optional[str]:
+        """Select best ETF for a given concept, applying liquidity veto + momentum tiebreak."""
+        codes = get_etf_pool_by_concept(concept, self.etf_pools)
+        if not codes:
+            return None
+        # Hard filter: liquidity
+        liquid_codes = self.sel.liquidity_veto(
+            codes, t, min_amt=self._liquid_min
+        )
+        if not liquid_codes:
+            return None
+        # Tiebreak: momentum
+        winners = self.sel.tiebreaker_momentum(
+            liquid_codes, t, top_n=1, window=self._momentum_window
+        )
+        return winners[0] if winners else None
+
+    def select_8(
+        self,
+        llm_scores: Dict[str, Dict[str, float]],
+        current_date: str,
+    ) -> Dict[str, str]:
+        """Select 8 ETFs based on LLM semantic scores and hard quant filters.
+
+        Args:
+            llm_scores: {concept_name: {"d1": float, "d2": float, "d3": float}}
+            current_date: Selection date string (YYYY-MM-DD)
+
+        Returns:
+            {slot_name: etf_code} dict with exactly 8 entries
+        """
+        result: Dict[str, str] = {}
+
+        # ── Slot 0: Wide Base (top 1) ───────────────────────────────────────
+        wide_scored = self._score_concepts_for_category(llm_scores, "wide_base")
+        if wide_scored:
+            concept, _, _ = wide_scored[0]
+            etf = self._select_one_by_concept(concept, current_date, "wide_base")
+            if etf:
+                result["0_宽基"] = etf
+
+        # ── Slots 1-3: Satellite (top 3 concepts, no industry overlap) ───────
+        satellite_scored = self._score_concepts_for_category(llm_scores, "satellite")
+        selected_satellite_concepts: list[str] = []
+        for concept, score, pool_type in satellite_scored:
+            if len(selected_satellite_concepts) >= 3:
+                break
+            etf = self._select_one_by_concept(concept, current_date, "satellite")
+            if etf is None:
+                continue
+            selected_satellite_concepts.append(concept)
+            slot_idx = len(selected_satellite_concepts)
+            result[f"{slot_idx}_卫星_{slot_idx}"] = etf
+
+        # Fill remaining satellite slots if not enough qualified
+        for i in range(len(selected_satellite_concepts) + 1, 4):
+            result[f"{i}_卫星_{i}"] = ""
+
+        # ── Slots 4-5: Fixed Income dumbbell ─────────────────────────────────
+        fi_concepts = ["长期利率债", "信用债"]
+        for idx, concept in enumerate(fi_concepts, start=4):
+            etf = self._select_one_by_concept(
+                concept, current_date, "fixed_income"
+            )
+            result[f"{idx}_固收_{concept}"] = etf if etf else ""
+
+        # ── Slot 6: Hedging (fixed gold ETF) ────────────────────────────────
+        gold_codes = FIXED_SLOT_ETFS.get("黄金", ["518880.SH"])
+        liquid_gold = self.sel.liquidity_veto(
+            gold_codes, current_date, min_amt=self._liquid_min
+        )
+        result["6_避险"] = liquid_gold[0] if liquid_gold else "518880.SH"
+
+        # ── Slot 7: Cash (fixed money market ETF) ───────────────────────────
+        cash_codes = FIXED_SLOT_ETFS.get("货币", ["511850.SH"])
+        liquid_cash = self.sel.liquidity_veto(
+            cash_codes, current_date, min_amt=self._liquid_min
+        )
+        result["7_现金"] = liquid_cash[0] if liquid_cash else "511850.SH"
+
+        return result

--- a/src/selection/clickhouse_hard_clip.py
+++ b/src/selection/clickhouse_hard_clip.py
@@ -1,0 +1,79 @@
+"""ClickHouse-based quantitative hard filters: liquidity veto and momentum tiebreaker."""
+
+from typing import Optional
+
+import pandas as pd
+
+from quantchdb import ClickHouseDatabase
+
+
+class ETFSelector:
+    """Local ClickHouse quantitative hard defense line.
+
+    Applies:
+    1. Liquidity veto: 5-day average amount must exceed threshold
+    2. Momentum tiebreaker: 20-day return ranking when scores tie
+    """
+
+    def __init__(self, config: dict):
+        self.config = config
+        db_cfg = config["data_pipeline"]["track_b"]["db_config"]
+        self.db = ClickHouseDatabase(config=db_cfg)
+
+    def liquidity_veto(
+        self,
+        codes: list[str],
+        t: str,
+        min_amt: int = 30_000_000,
+    ) -> list[str]:
+        """Return codes passing 5-day avg amount >= min_amt.
+
+        Strictly historical window: [t-5, t] (t is latest date in window).
+        """
+        if not codes:
+            return []
+        codes_str = ",".join(f"'{c}'" for c in codes)
+        sql = f"""
+        SELECT
+            code,
+            SUM(amount) / 5 AS avg_amt
+        FROM etf.etf_daily
+        WHERE date BETWEEN dateSub(5, DAY, '{t}') AND '{t}'
+          AND code IN ({codes_str})
+        GROUP BY code
+        HAVING avg_amt >= {min_amt}
+        """
+        df: pd.DataFrame = self.db.fetch(sql)
+        return df["code"].tolist() if not df.empty else []
+
+    def tiebreaker_momentum(
+        self,
+        codes: list[str],
+        t: str,
+        top_n: int = 1,
+        window: int = 20,
+    ) -> list[str]:
+        """Return top-N codes by 20-day momentum (strictly historical).
+
+        Window: [t-25, t] to compute 20-day return, QUALIFY picks latest date.
+        """
+        if not codes:
+            return []
+        codes_str = ",".join(f"'{c}'" for c in codes)
+        sql = f"""
+        SELECT
+            code,
+            (close - lagInFrame(close, {window}) OVER (
+                PARTITION BY code ORDER BY date
+            )) / lagInFrame(close, {window}) OVER (
+                PARTITION BY code ORDER BY date
+            ) AS momentum_{window}d
+        FROM etf.etf_daily
+        WHERE code IN ({codes_str})
+          AND date BETWEEN dateSub({window + 5}, DAY, '{t}') AND '{t}'
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY code ORDER BY date DESC) = 1
+        ORDER BY momentum_{window}d DESC
+        LIMIT {top_n}
+        """
+        df: pd.DataFrame = self.db.fetch(sql)
+        return df["code"].tolist() if not df.empty else []

--- a/src/selection/concept_to_etf_map.py
+++ b/src/selection/concept_to_etf_map.py
@@ -1,0 +1,57 @@
+"""Concept -> ETF pool mapping with configurable override support."""
+
+from typing import Optional
+
+# 概念名称 -> 对应ETF代码池（示例，需要可配置）
+DEFAULT_ETF_POOLS = {
+    "人工智能": ["159819.SZ", "515070.SH"],
+    "创新药": ["512010.SH", "159992.SZ"],
+    "半导体": ["512480.SH", "159813.SZ"],
+    "煤炭": ["515220.SH"],
+    "新能源": ["515030.SH", "159928.SZ"],
+    "红利低波": ["515050.SH"],
+    "沪深300": ["510300.SH"],
+    "中证1000": ["512100.SH"],
+    "长期利率债": ["511010.SH"],
+    "信用债": ["511020.SH"],
+    "黄金": ["518880.SH"],
+    "货币": ["511850.SH"],
+}
+
+# 概念 -> 插槽类别映射
+CONCEPT_CATEGORY_MAP = {
+    # 宽基
+    "沪深300": "wide_base",
+    "中证1000": "wide_base",
+    # 卫星
+    "人工智能": "satellite",
+    "创新药": "satellite",
+    "半导体": "satellite",
+    "煤炭": "satellite",
+    "新能源": "satellite",
+    "红利低波": "satellite",
+    # 固收
+    "长期利率债": "fixed_income",
+    "信用债": "fixed_income",
+    # 避险
+    "黄金": "hedging",
+    # 现金
+    "货币": "cash",
+}
+
+# 固定插槽ETF（不参与评分排序）
+FIXED_SLOT_ETFS = {
+    "黄金": ["518880.SH"],
+    "货币": ["511850.SH"],
+}
+
+
+def get_etf_pool_by_concept(concept: str, etf_pools: Optional[dict] = None) -> list[str]:
+    """Get ETF pool for a given concept, with optional runtime override."""
+    pools = etf_pools if etf_pools is not None else DEFAULT_ETF_POOLS
+    return pools.get(concept, [])
+
+
+def get_concepts_by_category(category: str) -> list[str]:
+    """Return all concepts belonging to a given slot category."""
+    return [c for c, cat in CONCEPT_CATEGORY_MAP.items() if cat == category]

--- a/src/selection/slot_weighting.py
+++ b/src/selection/slot_weighting.py
@@ -1,0 +1,40 @@
+"""Slot-specific P-weight vectors for score computation.
+
+Score = p1*d1 + p2*d2 - p3*d3
+where:
+  d1 = policy_signal_score   (政策信号维度)
+  d2 = sector_momentum_score(行业动量维度)
+  d3 = valuation_risk_score  (估值风险维度)
+"""
+
+from typing import Dict
+
+import numpy as np
+
+# 各插槽P权重向量（固定）
+P_VECTORS: Dict[str, np.ndarray] = {
+    "wide_base": np.array([0.6, 0.1, 0.3]),
+    "satellite": np.array([0.2, 0.6, 0.2]),
+    "fixed_income": np.array([0.5, 0.0, 0.5]),
+    "hedging": np.array([0.0, 0.0, 0.0]),  # 避险槽固定，不评分
+    "cash": np.array([0.0, 0.0, 0.0]),     # 现金槽固定，不评分
+}
+
+
+def compute_slot_score(d1: float, d2: float, d3: float, pool_type: str) -> float:
+    """
+    Compute weighted score for a given slot type.
+
+    Args:
+        d1: Policy signal dimension score
+        d2: Sector momentum dimension score
+        d3: Valuation risk dimension score (penalizes, hence minus sign)
+        pool_type: One of 'wide_base', 'satellite', 'fixed_income'
+
+    Returns:
+        Composite score as float
+    """
+    if pool_type not in P_VECTORS:
+        raise ValueError(f"Unknown pool_type: {pool_type}")
+    p = P_VECTORS[pool_type]
+    return float(p[0] * d1 + p[1] * d2 - p[2] * d3)


### PR DESCRIPTION
## Issue #10: 本地非对称扩维筛选

### 实现内容
- [x] src/selection/concept_to_etf_map.py — 概念->ETF池映射
- [x] src/selection/slot_weighting.py — P权重向量 + Score计算
- [x] src/selection/clickhouse_hard_clip.py — 流动性否决(30M) + Tiebreaker
- [x] src/selection/asymmetric_argmax.py — 8槽位选基逻辑
- [x] config.yaml — selection配置

### 8槽位规则
- 宽基x1: Score第1 → 流动性否决 → 动量Tiebreaker
- 卫星x3: Score前3（不同行业） → 流动性否决 → 动量Tiebreaker
- 固收x2: 利率债+信用债（哑铃） → 流动性否决
- 避险x1: 固定518880.SH（黄金）
- 现金x1: 固定511850.SH（货币）

### 约束红线
- [x] q1: SQL窗口严格历史
- [x] q3: P权重/流动性阈值入config.yaml
- [x] a1/a2: 无冗余代码，原子化提交

Closes #10